### PR TITLE
Allow serializing disciminator field into a xml-attribute

### DIFF
--- a/src/JMS/Serializer/Annotation/Discriminator.php
+++ b/src/JMS/Serializer/Annotation/Discriminator.php
@@ -32,4 +32,7 @@ class Discriminator
 
     /** @var boolean */
     public $disabled = false;
+
+    /** @var boolean */
+    public $xmlAttribute = false;
 }

--- a/src/JMS/Serializer/Metadata/ClassMetadata.php
+++ b/src/JMS/Serializer/Metadata/ClassMetadata.php
@@ -56,8 +56,9 @@ class ClassMetadata extends MergeableClassMetadata
     public $discriminatorFieldName;
     public $discriminatorValue;
     public $discriminatorMap = array();
+    public $discriminatorXmlAttribute = false;
 
-    public function setDiscriminator($fieldName, array $map)
+    public function setDiscriminator($fieldName, array $map, $xmlAttribute = false)
     {
         if (empty($fieldName)) {
             throw new \InvalidArgumentException('The $fieldName cannot be empty.');
@@ -70,6 +71,7 @@ class ClassMetadata extends MergeableClassMetadata
         $this->discriminatorBaseClass = $this->name;
         $this->discriminatorFieldName = $fieldName;
         $this->discriminatorMap = $map;
+        $this->discriminatorXmlAttribute = $xmlAttribute;
     }
 
     /**
@@ -186,6 +188,8 @@ class ClassMetadata extends MergeableClassMetadata
                 $this->discriminatorFieldName,
                 $typeValue
             );
+            $discriminatorProperty->xmlAttribute = $this->discriminatorXmlAttribute;
+
             $discriminatorProperty->serializedName = $this->discriminatorFieldName;
             $this->propertyMetadata[$this->discriminatorFieldName] = $discriminatorProperty;
         }

--- a/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
+++ b/src/JMS/Serializer/Metadata/Driver/AnnotationDriver.php
@@ -97,7 +97,7 @@ class AnnotationDriver implements DriverInterface
                 if ($annot->disabled) {
                     $classMetadata->discriminatorDisabled = true;
                 } else {
-                    $classMetadata->setDiscriminator($annot->field, $annot->map);
+                    $classMetadata->setDiscriminator($annot->field, $annot->map, $annot->xmlAttribute);
                 }
             }
         }

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorChild.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorChild.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * This file is part of the TWT eCommerce platform package.
+ *
+ * (c) TWT Interactive GmbH <info@twt.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+
+
+class ObjectWithXmlAttributeDiscriminatorChild extends ObjectWithXmlAttributeDiscriminatorParent
+{
+
+}

--- a/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
+++ b/tests/JMS/Serializer/Tests/Fixtures/Discriminator/ObjectWithXmlAttributeDiscriminatorParent.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * This file is part of the TWT eCommerce platform package.
+ *
+ * (c) TWT Interactive GmbH <info@twt.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures\Discriminator;
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * @Serializer\Discriminator(field = "type", map = {
+ *    "child": "JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild"
+ * },
+ *     xmlAttribute=true)
+ */
+class ObjectWithXmlAttributeDiscriminatorParent
+{
+
+}

--- a/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php
@@ -23,6 +23,7 @@ use JMS\Serializer\Handler\DateHandler;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
+use JMS\Serializer\Tests\Fixtures\Discriminator\ObjectWithXmlAttributeDiscriminatorChild;
 use JMS\Serializer\Tests\Fixtures\InvalidUsageOfXmlValue;
 use JMS\Serializer\Exception\InvalidArgumentException;
 use JMS\Serializer\Tests\Fixtures\PersonCollection;
@@ -233,6 +234,12 @@ class XmlSerializationTest extends BaseSerializationTest
 
 
         $this->assertEquals($this->getContent('simple_subclass_object'), $this->serialize($childObject));
+    }
+
+    public function testDiscriminatorAsXmlAttribute()
+    {
+        $xml = simplexml_load_string($this->serialize(new ObjectWithXmlAttributeDiscriminatorChild()));
+        $this->assertEquals('type="child"', trim($xml->xpath('//result/@type')[0]->saveXML()));
     }
 
     private function xpathFirstToString(\SimpleXMLElement $xml, $xpath)


### PR DESCRIPTION
Added parameter to @Discriminator annotation to allow serialization of discriminator into a XmlAttribute